### PR TITLE
Fix incorrect passing of keepalive values 

### DIFF
--- a/src/mosquitto.adb
+++ b/src/mosquitto.adb
@@ -338,7 +338,7 @@ package body Mosquitto is
         (Mosq      => Mosq.Handle,
          Host      => L_Host,
          Port      => Int (Port),
-         Keepalive => Int (Keepalive * 1000));
+         Keepalive => Int (Keepalive));
       Free (L_Host);
       Retcode_2_Exception (Ret);
       Mosq.Wait_Until_Connected;
@@ -383,7 +383,7 @@ package body Mosquitto is
         (Mosq         => Mosq.Handle,
          Host         => L_Host,
          Port         => Int (Port),
-         Keepalive    => Int (Keepalive * 1000),
+         Keepalive    => Int (Keepalive),
          Bind_Address => L_Bind_Address);
       Free (L_Host);
       Free (L_Bind_Address);
@@ -409,7 +409,7 @@ package body Mosquitto is
         (Mosq      => Mosq.Handle,
          Host      => L_Host,
          Port      => Int (Port),
-         Keepalive => Int (Keepalive * 1000));
+         Keepalive => Int (Keepalive));
       Free (L_Host);
       Retcode_2_Exception (Ret);
    end Connect_Async;
@@ -434,7 +434,7 @@ package body Mosquitto is
         (Mosq         => Mosq.Handle,
          Host         => L_Host,
          Port         => Int (Port),
-         Keepalive    => Int (Keepalive * 1000),
+         Keepalive    => Int (Keepalive),
          Bind_Address => L_Bind_Address);
       Free (L_Host);
       Free (L_Bind_Address);
@@ -459,7 +459,7 @@ package body Mosquitto is
       Ret := Mosquitto_Connect_Srv
         (Mosq         => Mosq.Handle,
          Host         => L_Host,
-         Keepalive    => Int (Keepalive * 1000),
+         Keepalive    => Int (Keepalive),
          Bind_Address => L_Bind_Address);
       Free (L_Host);
       Free (L_Bind_Address);
@@ -792,7 +792,7 @@ package body Mosquitto is
 
    Package_Initialization_Controler : Controler with Unreferenced;
 
-   function Is_Initialzed (Mosq          : Handle) return Boolean is
+   function Is_Initialzed (Mosq : Handle) return Boolean is
    begin
       return Mosq.Handle /= System.Null_Address;
    end;

--- a/src/mosquitto.ads
+++ b/src/mosquitto.ads
@@ -130,7 +130,7 @@ package Mosquitto is
    --  port -      the network port to connect to.
    --  keepalive - the number of seconds after which the broker should send a PING
    --             message to the client if no other messages have been exchanged
-   --             in that time.
+   --             in that time (decimal part will be ignored).
 
    not overriding
    procedure Set_Handler (Mosq      : in out Handle;

--- a/tests/src/mosquitto-tests-main.adb
+++ b/tests/src/mosquitto-tests-main.adb
@@ -24,7 +24,7 @@ begin
    C.Initialize (GNAT.Sockets.Host_Name & "/" & Ada.Directories.Simple_Name (Ada.Command_Line.Command_Name) & Getpid'Img);
    P.Start;
    C.Set_Handler (A'Unchecked_Access);
-   C.Connect ("mqtt");
+   C.Connect (Host => "mqtt", Keepalive => 30.0);
    C.Subscribe (Topic => "#");
    C.Publish (Mid => null, Topic => "test", Payload => "[" & GNAT.Time_Stamp.Current_Time & "] Hej", Qos => QOS_0, Retain => False);
    delay 1.0;


### PR DESCRIPTION
The C library expects integer seconds, while the Ada binding was passing
milliseconds.

Additionally, some versions have problems with a keepalive value of 0, so
the test is using 30, now.

See issue #1.